### PR TITLE
Create entertainment tracker front-end layout

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,34 @@
+const tabButtons = document.querySelectorAll('.tab-button');
+const tabContents = document.querySelectorAll('.tab-content');
+
+function setActiveTab(id) {
+  tabButtons.forEach((button) => {
+    button.classList.toggle('active', button.dataset.target === id);
+  });
+
+  tabContents.forEach((section) => {
+    section.classList.toggle('active', section.id === id);
+  });
+}
+
+tabButtons.forEach((button) => {
+  button.addEventListener('click', () => setActiveTab(button.dataset.target));
+});
+
+// Toggle status button state
+const statusButtons = document.querySelectorAll('.status-button');
+statusButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    button.classList.toggle('complete');
+  });
+});
+
+// Render star ratings using dataset values
+const starCells = document.querySelectorAll('.stars');
+starCells.forEach((cell) => {
+  const value = Number(cell.dataset.stars) || 0;
+  const maxStars = 5;
+  const filled = '★'.repeat(Math.min(value, maxStars));
+  const empty = '☆'.repeat(Math.max(maxStars - value, 0));
+  cell.textContent = `${filled}${empty}`;
+});

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,503 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Restworld Tracker</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="top-nav">
+      <h1>Restworld</h1>
+      <nav>
+        <button class="tab-button active" data-target="filmes">Filmes</button>
+        <button class="tab-button" data-target="series">Séries</button>
+        <button class="tab-button" data-target="games">Games</button>
+        <button class="tab-button" data-target="read">Read</button>
+      </nav>
+    </header>
+
+    <main>
+      <section id="filmes" class="tab-content active">
+        <h2>Filmes</h2>
+        <div class="table-grid">
+          <article class="table-card">
+            <h3>Assistir</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Título</th>
+                  <th>Status</th>
+                  <th>Prioridade</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Duna: Parte Dois</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+                <tr>
+                  <td>Oppenheimer</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="4"></td>
+                </tr>
+                <tr>
+                  <td>Interestelar</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="5"></td>
+                </tr>
+                <tr>
+                  <td>Blade Runner 2049</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+                <tr>
+                  <td>A Chegada</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="1"></td>
+                </tr>
+                <tr>
+                  <td>Nope</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+                <tr>
+                  <td>Noites Brancas</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+                <tr>
+                  <td>Clube da Luta</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="4"></td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+          <article class="table-card">
+            <h3>Reassistir</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Título</th>
+                  <th>Status</th>
+                  <th>Prioridade</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Matrix</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="5"></td>
+                </tr>
+                <tr>
+                  <td>O Senhor dos Anéis</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="4"></td>
+                </tr>
+                <tr>
+                  <td>Inception</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+                <tr>
+                  <td>O Cavaleiro das Trevas</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+                <tr>
+                  <td>Parasita</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="1"></td>
+                </tr>
+                <tr>
+                  <td>Whiplash</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="5"></td>
+                </tr>
+                <tr>
+                  <td>O Grande Truque</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+                <tr>
+                  <td>Gravidade</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+        </div>
+      </section>
+
+      <section id="series" class="tab-content">
+        <h2>Séries</h2>
+        <div class="table-grid">
+          <article class="table-card">
+            <h3>Assistir</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Título</th>
+                  <th>Status</th>
+                  <th>Prioridade</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Severance</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="4"></td>
+                </tr>
+                <tr>
+                  <td>Dark</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="5"></td>
+                </tr>
+                <tr>
+                  <td>Succession</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+                <tr>
+                  <td>Westworld</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+                <tr>
+                  <td>The Bear</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="1"></td>
+                </tr>
+                <tr>
+                  <td>Foundation</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="4"></td>
+                </tr>
+                <tr>
+                  <td>Arcane</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+                <tr>
+                  <td>Andor</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+          <article class="table-card">
+            <h3>Reassistir</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Título</th>
+                  <th>Status</th>
+                  <th>Prioridade</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Breaking Bad</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="5"></td>
+                </tr>
+                <tr>
+                  <td>Better Call Saul</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="4"></td>
+                </tr>
+                <tr>
+                  <td>Mad Men</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+                <tr>
+                  <td>Lost</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+                <tr>
+                  <td>Fringe</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="1"></td>
+                </tr>
+                <tr>
+                  <td>The Office</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="5"></td>
+                </tr>
+                <tr>
+                  <td>Community</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+                <tr>
+                  <td>Mr. Robot</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="4"></td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+        </div>
+      </section>
+
+      <section id="games" class="tab-content">
+        <h2>Games</h2>
+        <div class="table-grid grid-three">
+          <article class="table-card">
+            <h3>Backlog</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Título</th>
+                  <th>Status</th>
+                  <th>Prioridade</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Hollow Knight</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="4"></td>
+                </tr>
+                <tr>
+                  <td>Elden Ring</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="5"></td>
+                </tr>
+                <tr>
+                  <td>Persona 5</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+                <tr>
+                  <td>Death Stranding</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+                <tr>
+                  <td>Disco Elysium</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="1"></td>
+                </tr>
+                <tr>
+                  <td>God of War Ragnarök</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="5"></td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+          <article class="table-card">
+            <h3>Jogando</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Título</th>
+                  <th>Status</th>
+                  <th>Prioridade</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Cyberpunk 2077</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="4"></td>
+                </tr>
+                <tr>
+                  <td>Sea of Stars</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+                <tr>
+                  <td>Hades II</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="5"></td>
+                </tr>
+                <tr>
+                  <td>Baldur's Gate 3</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+                <tr>
+                  <td>Dead Cells</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="1"></td>
+                </tr>
+                <tr>
+                  <td>Slay the Spire</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+          <article class="table-card">
+            <h3>Rejogar</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Título</th>
+                  <th>Status</th>
+                  <th>Prioridade</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>The Witcher 3</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="5"></td>
+                </tr>
+                <tr>
+                  <td>Mass Effect 2</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="4"></td>
+                </tr>
+                <tr>
+                  <td>Dark Souls</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+                <tr>
+                  <td>Portal 2</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+                <tr>
+                  <td>Celeste</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="1"></td>
+                </tr>
+                <tr>
+                  <td>Journey</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+        </div>
+      </section>
+
+      <section id="read" class="tab-content">
+        <h2>Read</h2>
+        <div class="table-grid grid-three">
+          <article class="table-card">
+            <h3>Lista de Leitura</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Título</th>
+                  <th>Status</th>
+                  <th>Prioridade</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Neuromancer</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="4"></td>
+                </tr>
+                <tr>
+                  <td>Fundação</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="5"></td>
+                </tr>
+                <tr>
+                  <td>Duna</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+                <tr>
+                  <td>Snow Crash</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+                <tr>
+                  <td>Kindred</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="1"></td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+          <article class="table-card">
+            <h3>Lendo</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Título</th>
+                  <th>Status</th>
+                  <th>Prioridade</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>O Problema dos Três Corpos</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="4"></td>
+                </tr>
+                <tr>
+                  <td>A Longa Viagem a um Pequeno Planeta Hostil</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+                <tr>
+                  <td>Leviatã Desperta</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="5"></td>
+                </tr>
+                <tr>
+                  <td>Kindle Collection</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+          <article class="table-card">
+            <h3>Reler</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Título</th>
+                  <th>Status</th>
+                  <th>Prioridade</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>1984</td>
+                  <td><button class="status-button complete" aria-label="Marcar como incompleto"></button></td>
+                  <td class="stars" data-stars="5"></td>
+                </tr>
+                <tr>
+                  <td>Admirável Mundo Novo</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="4"></td>
+                </tr>
+                <tr>
+                  <td>Fundação e Império</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="3"></td>
+                </tr>
+                <tr>
+                  <td>O Nome do Vento</td>
+                  <td><button class="status-button" aria-label="Marcar como completo"></button></td>
+                  <td class="stars" data-stars="2"></td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,234 @@
+:root {
+  --background: #0c1b33;
+  --accent: #ff8c42;
+  --text-primary: #ffffff;
+  --text-secondary: #f7b733;
+  --text-highlight: #ffb347;
+  --table-border: rgba(255, 255, 255, 0.15);
+  --table-row-bg: rgba(255, 255, 255, 0.05);
+  --button-bg: #12264d;
+  --button-bg-hover: #173162;
+  --button-radius: 8px;
+  --nav-height: 72px;
+  font-family: "Segoe UI", "Roboto", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #071021 0%, #0c1b33 100%);
+  color: var(--text-primary);
+  font-family: inherit;
+  display: flex;
+  flex-direction: column;
+}
+
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(7, 16, 33, 0.9);
+  backdrop-filter: blur(12px);
+  padding: 12px 32px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+  height: var(--nav-height);
+}
+
+.top-nav h1 {
+  font-size: 1.4rem;
+  letter-spacing: 0.12em;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
+.top-nav nav {
+  display: flex;
+  gap: 12px;
+}
+
+.tab-button {
+  border: none;
+  background: var(--button-bg);
+  color: var(--text-primary);
+  padding: 10px 18px;
+  border-radius: var(--button-radius);
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.tab-button:hover,
+.tab-button:focus {
+  background: var(--button-bg-hover);
+  transform: translateY(-1px);
+}
+
+.tab-button.active {
+  background: var(--accent);
+  color: #1b1b1b;
+}
+
+main {
+  flex: 1;
+  padding: 32px;
+  display: grid;
+}
+
+.tab-content {
+  display: none;
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.tab-content.active {
+  display: block;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.tab-content h2 {
+  margin-bottom: 24px;
+  font-size: 2rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.table-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.table-grid.grid-three {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.table-card {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+}
+
+.table-card h3 {
+  margin-bottom: 16px;
+  font-size: 1.2rem;
+  color: var(--accent);
+  letter-spacing: 0.08em;
+}
+
+table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: rgba(2, 8, 18, 0.65);
+  border: 1px solid var(--table-border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+th,
+td {
+  padding: 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--table-border);
+}
+
+th {
+  background: rgba(255, 255, 255, 0.06);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+tbody tr:nth-child(even) {
+  background: var(--table-row-bg);
+}
+
+tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.status-button {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(135deg, #0f4aa3, #2561d9);
+  box-shadow: inset 0 2px 4px rgba(255, 255, 255, 0.3);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.status-button.complete {
+  background: linear-gradient(135deg, #ff7a18, #ffb347);
+  box-shadow: inset 0 2px 4px rgba(255, 255, 255, 0.35);
+}
+
+.status-button:focus,
+.status-button:hover {
+  transform: scale(1.05);
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.1);
+}
+
+.stars::before {
+  content: attr(data-stars) "★";
+  color: var(--accent);
+  letter-spacing: 0.1em;
+}
+
+.stars {
+  font-weight: bold;
+  font-size: 0.95rem;
+}
+
+/* Row color coding */
+tbody tr:nth-child(-n + 2) {
+  color: #ffe066;
+}
+
+tbody tr:nth-child(n + 3):nth-child(-n + 7) {
+  color: #ffb347;
+}
+
+tbody tr:nth-child(n + 8):nth-child(-n + 30) {
+  color: #ffffff;
+}
+
+@media (max-width: 900px) {
+  .top-nav {
+    flex-direction: column;
+    height: auto;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .top-nav nav {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 600px) {
+  main {
+    padding: 24px 16px 48px;
+  }
+
+  .table-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static front-end structure with navigation tabs for Filmes, Séries, Games e Read
- implement global dark blue/orange theme with slim top navigation and reusable table cards
- render tabular content with priority stars, circular status toggles and category-specific grids

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d1bc311d608333a4ec1ef6bea78707